### PR TITLE
Fix wpua_get_avatar_url not passing args down

### DIFF
--- a/includes/class-wp-user-avatar-functions.php
+++ b/includes/class-wp-user-avatar-functions.php
@@ -53,7 +53,7 @@ class WP_User_Avatar_Functions {
     // First checking custom avatar.
     if( has_wp_user_avatar( $user_id ) ) {
 
-      $url = $this->get_wp_user_avatar_src( $user_id );
+      $url = $this->get_wp_user_avatar_src( $user_id, $args['size'] ?? '' );
 
     } else if( $wpua_disable_gravatar ) {
 

--- a/includes/class-wp-user-avatar-functions.php
+++ b/includes/class-wp-user-avatar-functions.php
@@ -53,7 +53,7 @@ class WP_User_Avatar_Functions {
     // First checking custom avatar.
     if( has_wp_user_avatar( $user_id ) ) {
 
-      $url = $this->get_wp_user_avatar_src( $user_id, $args['size'] ?? '' );
+      $url = $this->get_wp_user_avatar_src( $user_id, isset($args['size']) ? $args['size'] : '' );
 
     } else if( $wpua_disable_gravatar ) {
 


### PR DESCRIPTION
Fix the function wpua_get_avatar_url. The received parameter $args[‘size’] was not being passed down to $this->get_wp_user_avatar_src at line 56.

Created the PR as suggested by the author here: https://wordpress.org/support/topic/wpua_get_avatar_url-not-passing-argssize-down/#post-14026957